### PR TITLE
feat(ios): Phase 11 - タブバー拡張（3タブ構成）

### DIFF
--- a/ios/TempoAI/TempoAI.xcodeproj/project.pbxproj
+++ b/ios/TempoAI/TempoAI.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		AAAA0001000000000000006 /* HealthKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0002000000000000006 /* HealthKitManager.swift */; };
 		AAAA0001000000000000007 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0002000000000000007 /* LocationManager.swift */; };
 		AAAA0001000000000000008 /* DebugResetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0002000000000000008 /* DebugResetService.swift */; };
+		BBBB0001000000000000001 /* CircadianRhythmPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 		AAAA0002000000000000006 /* HealthKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitManager.swift; sourceTree = "<group>"; };
 		AAAA0002000000000000007 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		AAAA0002000000000000008 /* DebugResetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugResetService.swift; sourceTree = "<group>"; };
+		BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircadianRhythmPlaceholderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,10 +163,27 @@
 		6978C77A2EE96C5E00FCDC58 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				BBBB0003000000000000001 /* CircadianRhythm */,
 				3B10E21D85B64C78A75D885B /* Home */,
 				6978C7792EE96C5E00FCDC58 /* Onboarding */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		BBBB0003000000000000001 /* CircadianRhythm */ = {
+			isa = PBXGroup;
+			children = (
+				BBBB0004000000000000001 /* Views */,
+			);
+			path = CircadianRhythm;
+			sourceTree = "<group>";
+		};
+		BBBB0004000000000000001 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		6978C77C2EE96C5E00FCDC58 /* Services */ = {
@@ -426,6 +445,7 @@
 				AAAA0001000000000000006 /* HealthKitManager.swift in Sources */,
 				AAAA0001000000000000007 /* LocationManager.swift in Sources */,
 				AAAA0001000000000000008 /* DebugResetService.swift in Sources */,
+				BBBB0001000000000000001 /* CircadianRhythmPlaceholderView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianRhythmPlaceholderView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianRhythmPlaceholderView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct CircadianRhythmPlaceholderView: View {
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 24) {
+        Image(systemName: "clock.arrow.2.circlepath")
+          .font(.system(size: 64))
+          .foregroundColor(.tempoSageGreen)
+
+        Text("サーカディアンリズム")
+          .font(.title2)
+          .fontWeight(.semibold)
+
+        Text("Phase 12で実装予定")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(Color.tempoBackground)
+      .navigationTitle("リズム")
+      .navigationBarTitleDisplayMode(.large)
+    }
+  }
+}
+
+#if DEBUG
+#Preview {
+  CircadianRhythmPlaceholderView()
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/Home/Views/MainTabView.swift
+++ b/ios/TempoAI/TempoAI/Features/Home/Views/MainTabView.swift
@@ -12,12 +12,19 @@ struct MainTabView: View {
         }
         .tag(0)
 
+      CircadianRhythmPlaceholderView()
+        .tabItem {
+          Image(systemName: "clock.arrow.2.circlepath")
+          Text("リズム")
+        }
+        .tag(1)
+
       SettingsPlaceholderView()
         .tabItem {
           Image(systemName: "gearshape.fill")
           Text("設定")
         }
-        .tag(1)
+        .tag(2)
     }
     .accentColor(.tempoSageGreen)
   }
@@ -28,4 +35,3 @@ struct MainTabView: View {
   MainTabView(userProfile: UserProfile.sampleData)
 }
 #endif
-


### PR DESCRIPTION
## Summary

- タブバーを2タブから3タブに拡張（ホーム / リズム / 設定）
- サーカディアンリズムタブのプレースホルダー画面を新規作成
- Phase 12 で本実装予定

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `CircadianRhythmPlaceholderView.swift` | 新規作成 - プレースホルダー画面 |
| `MainTabView.swift` | 3タブ構成に変更 |
| `project.pbxproj` | 新規ファイルをプロジェクトに追加 |

## タブ構成

```
┌────────────┬──────────────────┬────────────┐
│  🏠 ホーム  │   🔄 リズム      │  ⚙️ 設定   │
│   (tag: 0) │    (tag: 1)      │  (tag: 2)  │
└────────────┴──────────────────┴────────────┘
```

## Test Plan

- [ ] ビルドが通ること
- [ ] タブバーが3つ表示されること
- [ ] サーカディアンリズムタブでプレースホルダーが表示されること
- [ ] デフォルトタブがホームであること
- [ ] SwiftLintエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Circadian Rhythm" tab to the main navigation menu with a clock icon, expanding the app's feature set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->