### PR TITLE
feat(ios): Phase 12 - サーカディアンリズム画面実装

### DIFF
--- a/ios/TempoAI/TempoAI.xcodeproj/project.pbxproj
+++ b/ios/TempoAI/TempoAI.xcodeproj/project.pbxproj
@@ -46,6 +46,12 @@
 		AAAA0001000000000000007 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0002000000000000007 /* LocationManager.swift */; };
 		AAAA0001000000000000008 /* DebugResetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0002000000000000008 /* DebugResetService.swift */; };
 		BBBB0001000000000000001 /* CircadianRhythmPlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */; };
+		CCCC0001000000000000001 /* CircadianData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000001 /* CircadianData.swift */; };
+		CCCC0001000000000000002 /* CircadianCircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000002 /* CircadianCircleView.swift */; };
+		CCCC0001000000000000003 /* RhythmStabilityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000003 /* RhythmStabilityView.swift */; };
+		CCCC0001000000000000004 /* MetricsTriangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000004 /* MetricsTriangleView.swift */; };
+		CCCC0001000000000000005 /* InsightCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000005 /* InsightCardView.swift */; };
+		CCCC0001000000000000006 /* CircadianRhythmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCC0002000000000000006 /* CircadianRhythmView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -101,6 +107,12 @@
 		AAAA0002000000000000007 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		AAAA0002000000000000008 /* DebugResetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugResetService.swift; sourceTree = "<group>"; };
 		BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircadianRhythmPlaceholderView.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000001 /* CircadianData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircadianData.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000002 /* CircadianCircleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircadianCircleView.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000003 /* RhythmStabilityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RhythmStabilityView.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000004 /* MetricsTriangleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsTriangleView.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000005 /* InsightCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCardView.swift; sourceTree = "<group>"; };
+		CCCC0002000000000000006 /* CircadianRhythmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircadianRhythmView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,15 +185,29 @@
 		BBBB0003000000000000001 /* CircadianRhythm */ = {
 			isa = PBXGroup;
 			children = (
+				CCCC0003000000000000001 /* Models */,
 				BBBB0004000000000000001 /* Views */,
 			);
 			path = CircadianRhythm;
 			sourceTree = "<group>";
 		};
+		CCCC0003000000000000001 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CCCC0002000000000000001 /* CircadianData.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		BBBB0004000000000000001 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CCCC0002000000000000002 /* CircadianCircleView.swift */,
 				BBBB0002000000000000001 /* CircadianRhythmPlaceholderView.swift */,
+				CCCC0002000000000000006 /* CircadianRhythmView.swift */,
+				CCCC0002000000000000005 /* InsightCardView.swift */,
+				CCCC0002000000000000004 /* MetricsTriangleView.swift */,
+				CCCC0002000000000000003 /* RhythmStabilityView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -446,6 +472,12 @@
 				AAAA0001000000000000007 /* LocationManager.swift in Sources */,
 				AAAA0001000000000000008 /* DebugResetService.swift in Sources */,
 				BBBB0001000000000000001 /* CircadianRhythmPlaceholderView.swift in Sources */,
+				CCCC0001000000000000001 /* CircadianData.swift in Sources */,
+				CCCC0001000000000000002 /* CircadianCircleView.swift in Sources */,
+				CCCC0001000000000000003 /* RhythmStabilityView.swift in Sources */,
+				CCCC0001000000000000004 /* MetricsTriangleView.swift in Sources */,
+				CCCC0001000000000000005 /* InsightCardView.swift in Sources */,
+				CCCC0001000000000000006 /* CircadianRhythmView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Models/CircadianData.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Models/CircadianData.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Data model for the Circadian Rhythm screen
+/// Contains HRV data, sleep times, rhythm stability, and AI insight
+struct CircadianData {
+  /// Current HRV value in milliseconds
+  let hrvValue: Int
+
+  /// 7-day average HRV in milliseconds
+  let hrvAverage: Int
+
+  /// Last night's bedtime
+  let bedtime: Date?
+
+  /// This morning's wake time
+  let wakeTime: Date?
+
+  /// Rhythm stability score (0-100)
+  let rhythmScore: Int
+
+  /// Number of consecutive days with stable rhythm
+  let consecutiveStableDays: Int
+
+  /// Health scores for HRV, sleep, rhythm, and activity
+  let scores: HealthScores
+
+  /// AI insight text with causal relationships
+  let insight: String
+
+  /// Percentage difference from 7-day average
+  var hrvDifferencePercent: Double {
+    guard hrvAverage > 0 else { return 0 }
+    return ((Double(hrvValue) - Double(hrvAverage)) / Double(hrvAverage)) * 100
+  }
+
+  /// Formatted HRV difference string (e.g., "+9%" or "-5%")
+  var hrvDifferenceText: String {
+    let percent = Int(hrvDifferencePercent.rounded())
+    if percent >= 0 {
+      return "+\(percent)%"
+    } else {
+      return "\(percent)%"
+    }
+  }
+
+  /// Formatted bedtime string (e.g., "23:15")
+  var bedtimeText: String {
+    guard let bedtime else { return "--:--" }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "HH:mm"
+    return formatter.string(from: bedtime)
+  }
+
+  /// Formatted wake time string (e.g., "7:05")
+  var wakeTimeText: String {
+    guard let wakeTime else { return "--:--" }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "H:mm"
+    return formatter.string(from: wakeTime)
+  }
+}
+
+// MARK: - Rhythm Status
+
+extension CircadianData {
+  /// Rhythm stability status based on score and consecutive days
+  enum RhythmStatus {
+    case excellent(days: Int)
+    case good
+    case unstable
+    case poor
+
+    var displayText: String {
+      switch self {
+      case .excellent(let days):
+        return "\(days)日連続で安定 → 回復効率アップ中"
+      case .good:
+        return "リズムが整っています"
+      case .unstable:
+        return "就寝時刻にばらつきがあります"
+      case .poor:
+        return "リズムの乱れが回復を妨げています"
+      }
+    }
+
+    var statusLabel: String {
+      switch self {
+      case .excellent:
+        return "良好"
+      case .good:
+        return "良好"
+      case .unstable:
+        return "やや不安定"
+      case .poor:
+        return "不安定"
+      }
+    }
+
+    var filledDots: Int {
+      switch self {
+      case .excellent:
+        return 5
+      case .good:
+        return 4
+      case .unstable:
+        return 3
+      case .poor:
+        return 2
+      }
+    }
+  }
+
+  var rhythmStatus: RhythmStatus {
+    switch rhythmScore {
+    case 70...100:
+      if consecutiveStableDays >= 3 {
+        return .excellent(days: consecutiveStableDays)
+      } else {
+        return .good
+      }
+    case 50..<70:
+      return .unstable
+    default:
+      return .poor
+    }
+  }
+}
+
+// MARK: - Mock Data
+
+extension CircadianData {
+  /// Mock data for development and previews
+  static var mock: CircadianData {
+    let calendar = Calendar.current
+    let now = Date()
+
+    // Create bedtime at 23:15 last night
+    var bedtimeComponents = calendar.dateComponents([.year, .month, .day], from: now)
+    bedtimeComponents.day! -= 1
+    bedtimeComponents.hour = 23
+    bedtimeComponents.minute = 15
+    let bedtime = calendar.date(from: bedtimeComponents)
+
+    // Create wake time at 7:05 this morning
+    var wakeComponents = calendar.dateComponents([.year, .month, .day], from: now)
+    wakeComponents.hour = 7
+    wakeComponents.minute = 5
+    let wakeTime = calendar.date(from: wakeComponents)
+
+    return CircadianData(
+      hrvValue: 72,
+      hrvAverage: 66,
+      bedtime: bedtime,
+      wakeTime: wakeTime,
+      rhythmScore: 78,
+      consecutiveStableDays: 3,
+      scores: HealthScores(hrv: 85, sleep: 82, rhythm: 78, activity: 70),
+      insight: "昨夜は就寝が30分早かったため、HRVが+9%改善しました。3日連続でリズムが安定しているため、回復効率がアップしています。"
+    )
+  }
+
+  /// Mock data with poor rhythm for testing
+  static var mockPoorRhythm: CircadianData {
+    CircadianData(
+      hrvValue: 45,
+      hrvAverage: 55,
+      bedtime: nil,
+      wakeTime: nil,
+      rhythmScore: 35,
+      consecutiveStableDays: 0,
+      scores: HealthScores(hrv: 45, sleep: 40, rhythm: 35, activity: 55),
+      insight: "睡眠リズムが不安定なため、HRVが低下しています。まずは就寝時刻を一定に保つことから始めてみましょう。"
+    )
+  }
+}

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianCircleView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianCircleView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+/// 24-hour circular visualization with zones, time cursor, and HRV display
+struct CircadianCircleView: View {
+  let data: CircadianData
+
+  /// Current time for cursor position (updates every minute)
+  @State private var currentTime = Date()
+
+  /// Timer for updating current time
+  private let timer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
+  /// Circle radius relative to view size
+  private let circleRadius: CGFloat = 0.4
+
+  var body: some View {
+    GeometryReader { geometry in
+      let size = min(geometry.size.width, geometry.size.height)
+      let center = CGPoint(x: geometry.size.width / 2, y: size / 2)
+      let radius = size * circleRadius
+
+      ZStack {
+        // Background circle
+        Circle()
+          .stroke(Color.gray.opacity(0.2), lineWidth: 2)
+          .frame(width: radius * 2, height: radius * 2)
+
+        // Zone arcs
+        zoneArcs(radius: radius)
+
+        // Time ticks
+        timeTicks(radius: radius)
+
+        // Current time cursor
+        timeCursor(radius: radius)
+
+        // Center content
+        centerContent
+      }
+      .frame(width: geometry.size.width, height: size)
+      .position(center)
+    }
+    .aspectRatio(1, contentMode: .fit)
+    .onReceive(timer) { _ in
+      currentTime = Date()
+    }
+  }
+
+  // MARK: - Zone Arcs
+
+  @ViewBuilder
+  private func zoneArcs(radius: CGFloat) -> some View {
+    // Sleep zone: 22:00 - 6:00
+    ZoneArc(
+      startHour: 22,
+      endHour: 6,
+      radius: radius,
+      color: .tempoSleepZone,
+      opacity: 0.3
+    )
+
+    // Morning focus zone: 9:00 - 12:00
+    ZoneArc(
+      startHour: 9,
+      endHour: 12,
+      radius: radius,
+      color: .tempoSageGreen,
+      opacity: 0.15
+    )
+
+    // Lunch rest zone: 12:00 - 14:00
+    ZoneArc(
+      startHour: 12,
+      endHour: 14,
+      radius: radius,
+      color: .tempoWarmBeige,
+      opacity: 0.25
+    )
+
+    // Afternoon focus zone: 14:00 - 17:00
+    ZoneArc(
+      startHour: 14,
+      endHour: 17,
+      radius: radius,
+      color: .tempoSageGreen,
+      opacity: 0.15
+    )
+  }
+
+  // MARK: - Time Ticks
+
+  @ViewBuilder
+  private func timeTicks(radius: CGFloat) -> some View {
+    ForEach([0, 6, 12, 18], id: \.self) { hour in
+      let angle = angleForHour(hour)
+      let tickRadius = radius + 15
+
+      Text(hourLabel(hour))
+        .font(.system(size: 12, weight: .medium))
+        .foregroundColor(.tempoSecondaryText)
+        .position(
+          x: tickRadius * cos(angle * .pi / 180),
+          y: tickRadius * sin(angle * .pi / 180)
+        )
+        .offset(x: radius, y: radius)
+    }
+  }
+
+  private func hourLabel(_ hour: Int) -> String {
+    if hour == 0 {
+      return "0"
+    }
+    return "\(hour)"
+  }
+
+  // MARK: - Time Cursor
+
+  @ViewBuilder
+  private func timeCursor(radius: CGFloat) -> some View {
+    let angle = angleForTime(currentTime)
+    let cursorRadius = radius - 15
+
+    Image(systemName: cursorIcon)
+      .font(.system(size: 24))
+      .foregroundColor(.tempoSageGreen)
+      .position(
+        x: cursorRadius * cos(angle * .pi / 180) + radius,
+        y: cursorRadius * sin(angle * .pi / 180) + radius
+      )
+  }
+
+  private var cursorIcon: String {
+    let hour = Calendar.current.component(.hour, from: currentTime)
+    // Day: 6:00 - 18:00, Night: 18:00 - 6:00
+    if hour >= 6 && hour < 18 {
+      return "sun.max.fill"
+    } else {
+      return "moon.fill"
+    }
+  }
+
+  // MARK: - Center Content
+
+  private var centerContent: some View {
+    VStack(spacing: 4) {
+      // HRV value
+      Text("\(data.hrvValue)")
+        .font(.system(size: 36, weight: .bold, design: .rounded))
+        .foregroundColor(.tempoPrimaryText)
+
+      Text("ms")
+        .font(.system(size: 14))
+        .foregroundColor(.tempoSecondaryText)
+
+      // Difference from average
+      HStack(spacing: 2) {
+        Image(systemName: data.hrvDifferencePercent >= 0 ? "arrow.up" : "arrow.down")
+          .font(.system(size: 10))
+        Text(data.hrvDifferenceText)
+          .font(.system(size: 12, weight: .medium))
+      }
+      .foregroundColor(data.hrvDifferencePercent >= 0 ? .tempoSuccess : .tempoWarning)
+
+      // Sleep times
+      Text("就寝 \(data.bedtimeText) / 起床 \(data.wakeTimeText)")
+        .font(.system(size: 11))
+        .foregroundColor(.tempoSecondaryText)
+        .padding(.top, 4)
+    }
+  }
+
+  // MARK: - Angle Calculations
+
+  /// Convert hour to angle (0:00 = top = -90 degrees)
+  private func angleForHour(_ hour: Int) -> Double {
+    (Double(hour) / 24.0) * 360.0 - 90.0
+  }
+
+  /// Convert time to angle
+  private func angleForTime(_ date: Date) -> Double {
+    let calendar = Calendar.current
+    let hour = calendar.component(.hour, from: date)
+    let minute = calendar.component(.minute, from: date)
+    let totalMinutes = Double(hour * 60 + minute)
+    return (totalMinutes / 1440.0) * 360.0 - 90.0
+  }
+}
+
+// MARK: - Zone Arc Shape
+
+private struct ZoneArc: View {
+  let startHour: Int
+  let endHour: Int
+  let radius: CGFloat
+  let color: Color
+  let opacity: Double
+
+  var body: some View {
+    Path { path in
+      let startAngle = angleForHour(startHour)
+      let endAngle = angleForHour(endHour)
+
+      path.addArc(
+        center: CGPoint(x: radius, y: radius),
+        radius: radius,
+        startAngle: .degrees(startAngle),
+        endAngle: .degrees(endAngle),
+        clockwise: startHour > endHour ? true : false
+      )
+    }
+    .stroke(color.opacity(opacity), lineWidth: 20)
+  }
+
+  private func angleForHour(_ hour: Int) -> Double {
+    (Double(hour) / 24.0) * 360.0 - 90.0
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Circadian Circle") {
+  CircadianCircleView(data: .mock)
+    .frame(width: 300, height: 300)
+    .padding()
+}
+
+#Preview("Circadian Circle - Poor Rhythm") {
+  CircadianCircleView(data: .mockPoorRhythm)
+    .frame(width: 300, height: 300)
+    .padding()
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianRhythmView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/CircadianRhythmView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Main view for the Circadian Rhythm tab
+/// Displays 24-hour circle, rhythm stability, metrics triangle, and AI insight
+struct CircadianRhythmView: View {
+  let data: CircadianData
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(spacing: 20) {
+          // 24-hour circle with HRV
+          CircadianCircleView(data: data)
+            .frame(height: 280)
+            .padding(.horizontal, 16)
+
+          // Rhythm stability
+          RhythmStabilityView(data: data)
+            .padding(.horizontal, 16)
+
+          // 3 metrics triangle
+          MetricsTriangleView(scores: data.scores)
+            .padding(.horizontal, 16)
+
+          // AI insight
+          InsightCardView(insight: data.insight)
+            .padding(.horizontal, 16)
+
+          // Bottom padding for tab bar
+          Spacer()
+            .frame(height: 20)
+        }
+        .padding(.top, 16)
+      }
+      .background(Color.tempoBackground)
+      .navigationTitle("リズム")
+      .navigationBarTitleDisplayMode(.large)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Circadian Rhythm - Good") {
+  CircadianRhythmView(data: .mock)
+}
+
+#Preview("Circadian Rhythm - Poor") {
+  CircadianRhythmView(data: .mockPoorRhythm)
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/InsightCardView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/InsightCardView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Displays AI insight with causal relationships
+struct InsightCardView: View {
+  let insight: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      // Header with icon
+      HStack(spacing: 8) {
+        Image(systemName: "brain.head.profile")
+          .font(.system(size: 16))
+          .foregroundColor(.tempoSageGreen)
+
+        Text("今日の見立て")
+          .font(.subheadline)
+          .fontWeight(.medium)
+          .foregroundColor(.tempoPrimaryText)
+      }
+
+      // Insight text
+      Text(insight)
+        .font(.body)
+        .foregroundColor(.tempoSecondaryText)
+        .lineSpacing(4)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 12)
+        .fill(Color.tempoLightCream)
+        .shadow(
+          color: Color.black.opacity(0.04),
+          radius: 4,
+          x: 0,
+          y: 2
+        )
+    )
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Insight Card - Good") {
+  InsightCardView(
+    insight: "昨夜は就寝が30分早かったため、HRVが+9%改善しました。3日連続でリズムが安定しているため、回復効率がアップしています。"
+  )
+  .padding()
+}
+
+#Preview("Insight Card - Poor") {
+  InsightCardView(
+    insight: "睡眠リズムが不安定なため、HRVが低下しています。まずは就寝時刻を一定に保つことから始めてみましょう。"
+  )
+  .padding()
+}
+
+#Preview("Insight Card - Long") {
+  InsightCardView(
+    // swiftlint:disable:next line_length
+    insight: "昨夜は普段より1時間遅い就寝でしたが、7時間の睡眠は確保できました。ただし、深い睡眠の割合が通常より少なめだったため、今朝のHRVは平均を少し下回っています。午後は軽めの活動にして、今夜は通常の時刻に就寝することをおすすめします。"
+  )
+  .padding()
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/MetricsTriangleView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/MetricsTriangleView.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+
+/// Displays three health metrics in a triangle layout
+/// HRV (top) = Result, Sleep (bottom-left) = Recovery, Activity (bottom-right) = Movement
+struct MetricsTriangleView: View {
+  let scores: HealthScores
+
+  var body: some View {
+    VStack(spacing: 16) {
+      // Header
+      Text("3つの指標")
+        .font(.subheadline)
+        .fontWeight(.medium)
+        .foregroundColor(.tempoPrimaryText)
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+      // Triangle layout
+      VStack(spacing: 24) {
+        // Top: HRV (Result)
+        MetricIndicator(
+          icon: "heart.fill",
+          label: "HRV",
+          value: "\(scores.hrv)",
+          unit: "点",
+          role: "結果",
+          score: scores.hrv
+        )
+
+        // Bottom row: Sleep and Activity
+        HStack(spacing: 40) {
+          // Bottom-left: Sleep (Recovery)
+          MetricIndicator(
+            icon: "moon.zzz.fill",
+            label: "睡眠",
+            value: "\(scores.sleep)",
+            unit: "点",
+            role: "回復",
+            score: scores.sleep
+          )
+
+          // Bottom-right: Activity (Movement)
+          MetricIndicator(
+            icon: "figure.walk",
+            label: "活動",
+            value: "\(scores.activity)",
+            unit: "点",
+            role: "活動",
+            score: scores.activity
+          )
+        }
+      }
+
+      // Connection lines (visual triangle)
+      TriangleConnector()
+        .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+        .frame(height: 60)
+        .offset(y: -100)
+    }
+    .padding(16)
+    .background(
+      RoundedRectangle(cornerRadius: 12)
+        .fill(Color.tempoLightCream)
+        .shadow(
+          color: Color.black.opacity(0.04),
+          radius: 4,
+          x: 0,
+          y: 2
+        )
+    )
+  }
+}
+
+// MARK: - Metric Indicator
+
+private struct MetricIndicator: View {
+  let icon: String
+  let label: String
+  let value: String
+  let unit: String
+  let role: String
+  let score: Int
+
+  var body: some View {
+    VStack(spacing: 6) {
+      // Icon
+      Image(systemName: icon)
+        .font(.system(size: 20))
+        .foregroundColor(scoreColor)
+
+      // Value
+      HStack(alignment: .lastTextBaseline, spacing: 2) {
+        Text(value)
+          .font(.system(size: 24, weight: .bold, design: .rounded))
+          .foregroundColor(.tempoPrimaryText)
+
+        Text(unit)
+          .font(.system(size: 12))
+          .foregroundColor(.tempoSecondaryText)
+      }
+
+      // Label and role
+      VStack(spacing: 2) {
+        Text(label)
+          .font(.system(size: 14, weight: .medium))
+          .foregroundColor(.tempoPrimaryText)
+
+        Text("（\(role)）")
+          .font(.system(size: 11))
+          .foregroundColor(.tempoSecondaryText)
+      }
+    }
+  }
+
+  private var scoreColor: Color {
+    switch score {
+    case 80...100:
+      return .tempoSuccess
+    case 60..<80:
+      return .tempoSageGreen
+    case 40..<60:
+      return .tempoWarning
+    case 20..<40:
+      return .orange
+    default:
+      return .tempoError
+    }
+  }
+}
+
+// MARK: - Triangle Connector Shape
+
+private struct TriangleConnector: Shape {
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+
+    let topCenter = CGPoint(x: rect.midX, y: rect.minY)
+    let bottomLeft = CGPoint(x: rect.minX + 40, y: rect.maxY)
+    let bottomRight = CGPoint(x: rect.maxX - 40, y: rect.maxY)
+
+    path.move(to: topCenter)
+    path.addLine(to: bottomLeft)
+    path.addLine(to: bottomRight)
+    path.addLine(to: topCenter)
+
+    return path
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Metrics Triangle - Good") {
+  MetricsTriangleView(scores: HealthScores(hrv: 85, sleep: 82, rhythm: 78, activity: 70))
+    .padding()
+}
+
+#Preview("Metrics Triangle - Mixed") {
+  MetricsTriangleView(scores: HealthScores(hrv: 65, sleep: 45, rhythm: 55, activity: 80))
+    .padding()
+}
+
+#Preview("Metrics Triangle - Low") {
+  MetricsTriangleView(scores: HealthScores(hrv: 35, sleep: 40, rhythm: 30, activity: 25))
+    .padding()
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/RhythmStabilityView.swift
+++ b/ios/TempoAI/TempoAI/Features/CircadianRhythm/Views/RhythmStabilityView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// Displays rhythm stability with dot indicators and status text
+struct RhythmStabilityView: View {
+  let data: CircadianData
+
+  private let totalDots = 5
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      // Header
+      Text("リズム安定度")
+        .font(.subheadline)
+        .fontWeight(.medium)
+        .foregroundColor(.tempoPrimaryText)
+
+      // Dots and status
+      HStack(spacing: 12) {
+        // Dot indicators
+        HStack(spacing: 4) {
+          ForEach(0..<totalDots, id: \.self) { index in
+            Circle()
+              .fill(index < data.rhythmStatus.filledDots ? statusColor : Color.gray.opacity(0.3))
+              .frame(width: 10, height: 10)
+          }
+        }
+
+        // Status label
+        Text(data.rhythmStatus.statusLabel)
+          .font(.subheadline)
+          .fontWeight(.semibold)
+          .foregroundColor(statusColor)
+      }
+
+      // Description text
+      Text(data.rhythmStatus.displayText)
+        .font(.footnote)
+        .foregroundColor(.tempoSecondaryText)
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: 12)
+        .fill(Color.tempoLightCream)
+        .shadow(
+          color: Color.black.opacity(0.04),
+          radius: 4,
+          x: 0,
+          y: 2
+        )
+    )
+  }
+
+  private var statusColor: Color {
+    switch data.rhythmStatus {
+    case .excellent, .good:
+      return .tempoSuccess
+    case .unstable:
+      return .tempoWarning
+    case .poor:
+      return .tempoError
+    }
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Rhythm Stability - Excellent") {
+  let data = CircadianData(
+    hrvValue: 72,
+    hrvAverage: 66,
+    bedtime: Date(),
+    wakeTime: Date(),
+    rhythmScore: 85,
+    consecutiveStableDays: 5,
+    scores: HealthScores(hrv: 85, sleep: 82, rhythm: 85, activity: 70),
+    insight: ""
+  )
+  return RhythmStabilityView(data: data)
+    .padding()
+}
+
+#Preview("Rhythm Stability - Good") {
+  RhythmStabilityView(data: .mock)
+    .padding()
+}
+
+#Preview("Rhythm Stability - Unstable") {
+  let data = CircadianData(
+    hrvValue: 55,
+    hrvAverage: 60,
+    bedtime: Date(),
+    wakeTime: Date(),
+    rhythmScore: 55,
+    consecutiveStableDays: 1,
+    scores: HealthScores(hrv: 55, sleep: 60, rhythm: 55, activity: 65),
+    insight: ""
+  )
+  return RhythmStabilityView(data: data)
+    .padding()
+}
+
+#Preview("Rhythm Stability - Poor") {
+  RhythmStabilityView(data: .mockPoorRhythm)
+    .padding()
+}
+#endif

--- a/ios/TempoAI/TempoAI/Features/Home/Views/MainTabView.swift
+++ b/ios/TempoAI/TempoAI/Features/Home/Views/MainTabView.swift
@@ -12,7 +12,7 @@ struct MainTabView: View {
         }
         .tag(0)
 
-      CircadianRhythmPlaceholderView()
+      CircadianRhythmView(data: .mock)
         .tabItem {
           Image(systemName: "clock.arrow.2.circlepath")
           Text("リズム")

--- a/ios/TempoAI/TempoAI/Shared/Extensions/Color+Extensions.swift
+++ b/ios/TempoAI/TempoAI/Shared/Extensions/Color+Extensions.swift
@@ -59,6 +59,15 @@ extension Color {
   /// Sleep: Night Blue
   static let tempoSleep: Color = Color(red: 0.46, green: 0.58, blue: 0.78)  // #7594C7
 
+  // MARK: - Circadian Rhythm Colors
+
+  /// Sleep Zone: Dark Gray for sleep time visualization
+  static let tempoSleepZone: Color = Color(red: 0.29, green: 0.29, blue: 0.29)  // #4A4A4A
+
+  /// Focus Zone: Uses Primary (Sage Green) with opacity in views
+
+  /// Rest Zone: Uses Secondary (Warm Beige) with opacity in views
+
   // MARK: - Component Colors
 
   /// Input Field Background


### PR DESCRIPTION
## Summary

- 24時間サークル図（CircadianCircleView）の実装
  - 集中ゾーン（9-12時, 14-17時）・休憩ゾーン（12-14時）・睡眠ゾーン（22-6時）の色分け
  - 現在時刻カーソル（太陽/月アイコン、毎分更新）
  - 中央HRV表示（7日平均との差分）
- リズム安定度表示（RhythmStabilityView）
  - スコアに応じた4段階のステータス表示
- 3指標三角形（MetricsTriangleView）
  - HRV（結果）/ 睡眠（回復）/ 活動（活動）の三角形レイアウト
- AIインサイトカード（InsightCardView）
- CircadianData モデル追加
- tempoSleepZone カラー追加

## Test plan

- [x] ビルド成功確認
- [x] SwiftLintエラーなし
- [ ] シミュレータで24時間サークルが正しく描画
- [ ] 現在時刻カーソルが正しく表示
- [ ] ゾーン色分けが仕様通り
- [ ] 3指標が三角形で表示
- [ ] リズム安定度がスコアに応じて変化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented the Circadian Rhythm tab with comprehensive sleep and heart rate variability (HRV) visualization
  * Added 24-hour circadian cycle visualization with live time indicator
  * Added rhythm stability indicator with visual status display
  * Added health metrics visualization including HRV, sleep, and activity tracking
  * Added personalized daily rhythm insights

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->